### PR TITLE
Allow proper usage of namespaces for openni's nodes and nodelets

### DIFF
--- a/launch/includes/depth.launch
+++ b/launch/includes/depth.launch
@@ -4,42 +4,45 @@
   <arg name="manager" />
   <arg name="points_xyz" default="true" />
   <arg name="rectify" default="true" />
-
   <arg name="respawn" default="false" />
   <arg     if="$(arg respawn)" name="bond" value="" />
   <arg unless="$(arg respawn)" name="bond" value="--no-bond" />
+  <arg name="depth" />
 
   <!-- Rectified raw image (internal use) -->
-  <node if="$(arg rectify)" pkg="nodelet" type="nodelet" name="rectify_depth"
+  <node if="$(arg rectify)" pkg="nodelet" type="nodelet" name="$(arg depth)_rectify_depth"
         args="load image_proc/rectify $(arg manager) $(arg bond)"
-	respawn="$(arg respawn)">
-    <remap from="image_mono"  to="image_raw" />
-    <remap from="image_rect"  to="image_rect_raw" />
-
+        respawn="$(arg respawn)">
+    <remap from="image_mono"  to="$(arg depth)/image_raw" />
+    <remap from="image_rect"  to="$(arg depth)/image_rect_raw" />
     <!-- Use nearest neighbor (0) interpolation so we don't streak across
-	 depth boundaries -->
+         depth boundaries -->
     <param name="interpolation" value="0" />
   </node>
 
   <!-- Rectified depth image -->
-  <node pkg="nodelet" type="nodelet" name="metric_rect"
+  <node pkg="nodelet" type="nodelet" name="$(arg depth)_metric_rect"
         args="load depth_image_proc/convert_metric $(arg manager) $(arg bond)"
-	respawn="$(arg respawn)">
-    <remap from="image_raw" to="image_rect_raw" />
-    <remap from="image"     to="image_rect" />
+        respawn="$(arg respawn)">
+    <remap from="image_raw" to="$(arg depth)/image_rect_raw" />
+    <remap from="image"     to="$(arg depth)/image_rect" />
+  </node>
+
+  <!-- Unrectified depth image -->
+  <node pkg="nodelet" type="nodelet" name="$(arg depth)_metric"
+        args="load depth_image_proc/convert_metric $(arg manager) $(arg bond)"
+        respawn="$(arg respawn)">
+    <remap from="image_raw" to="$(arg depth)/image_raw" />
+    <remap from="image"     to="$(arg depth)/image" />
   </node>
   
-  <!-- Unrectified depth image -->
-  <node pkg="nodelet" type="nodelet" name="metric"
-        args="load depth_image_proc/convert_metric $(arg manager) $(arg bond)"
-	respawn="$(arg respawn)" />
-
   <!-- XYZ point cloud (optional, disable if publishing XYZRGB instead) -->
   <node if="$(arg points_xyz)"
-	pkg="nodelet" type="nodelet" name="points"
+        pkg="nodelet" type="nodelet" name="$(arg depth)_points"
         args="load depth_image_proc/point_cloud_xyz $(arg manager) $(arg bond)"
-	respawn="$(arg respawn)">
-    <remap from="image_rect" to="image_rect_raw"/>  <!-- Use raw image for efficiency -->
+        respawn="$(arg respawn)">
+    <remap from="image_rect" to="$(arg depth)/image_rect_raw"/>  <!-- Use raw image for efficiency -->
+    <remap from="points"     to="$(arg depth)/points" />
   </node>
 
 </launch>

--- a/launch/includes/depth_registered.launch
+++ b/launch/includes/depth_registered.launch
@@ -20,7 +20,7 @@
   <!-- Registration nodelet, projecting depth to RGB camera -->
   <node pkg="nodelet" type="nodelet" name="register_$(arg suffix)"
         args="load depth_image_proc/register $(arg manager) $(arg bond)"
-	respawn="$(arg respawn)">
+        respawn="$(arg respawn)">
     <!-- Explicit topic remappings, shouldn't need all of these -->
     <remap from="rgb/camera_info"             to="$(arg rgb)/camera_info" />
     <remap from="depth/camera_info"           to="$(arg depth)/camera_info" />
@@ -29,17 +29,18 @@
   </node>
 
   <!-- Get all the usual depth topics -->
-  <include file="$(find openni_launch)/launch/includes/depth.launch"
-	   ns="$(arg depth_registered)">
+  <!-- Why do we launch additional depth nodelets? -->
+  <include file="$(find openni_launch)/launch/includes/depth.launch">
     <arg name="manager"    value="$(arg manager)" />
     <arg name="points_xyz" value="false" /> <!-- Suppress XYZ point cloud -->
-    <arg name="respawn" value="$(arg respawn)" />
+    <arg name="respawn"    value="$(arg respawn)" />
+    <arg name="depth"      value="$(arg depth_registered)" />
   </include>
 
   <!-- Instead publish registered XYZRGB point cloud -->
   <node pkg="nodelet" type="nodelet" name="points_xyzrgb_$(arg suffix)"
         args="load depth_image_proc/point_cloud_xyzrgb $(arg manager) $(arg bond)"
-	respawn="$(arg respawn)">
+        respawn="$(arg respawn)">
     <!-- Explicit topic remappings, shouldn't need all of these -->
     <remap from="rgb/image_rect_color"        to="$(arg rgb)/image_rect_color" />
     <remap from="rgb/camera_info"             to="$(arg rgb)/camera_info" />

--- a/launch/includes/depth_registered.launch
+++ b/launch/includes/depth_registered.launch
@@ -28,15 +28,6 @@
     <remap from="depth_registered/image_rect" to="$(arg depth_registered)/image_rect_raw" />
   </node>
 
-  <!-- Get all the usual depth topics -->
-  <!-- Why do we launch additional depth nodelets? -->
-  <include file="$(find openni_launch)/launch/includes/depth.launch">
-    <arg name="manager"    value="$(arg manager)" />
-    <arg name="points_xyz" value="false" /> <!-- Suppress XYZ point cloud -->
-    <arg name="respawn"    value="$(arg respawn)" />
-    <arg name="depth"      value="$(arg depth_registered)" />
-  </include>
-
   <!-- Instead publish registered XYZRGB point cloud -->
   <node pkg="nodelet" type="nodelet" name="points_xyzrgb_$(arg suffix)"
         args="load depth_image_proc/point_cloud_xyzrgb $(arg manager) $(arg bond)"

--- a/launch/includes/device.launch
+++ b/launch/includes/device.launch
@@ -26,7 +26,7 @@
   <!-- Driver nodelet -->
   <node pkg="nodelet" type="nodelet" name="driver" 
         args="load openni_camera/driver $(arg manager) $(arg bond)"
-	respawn="$(arg respawn)">
+        respawn="$(arg respawn)">
     <param name="device_id" value="$(arg device_id)" />
     <param name="rgb_camera_info_url"   value="$(arg rgb_camera_info_url)" />
     <param name="depth_camera_info_url" value="$(arg depth_camera_info_url)" />

--- a/launch/includes/disparity.launch
+++ b/launch/includes/disparity.launch
@@ -11,7 +11,7 @@
   <!-- Disparity image -->
   <node pkg="nodelet" type="nodelet" name="disparity_$(arg depth)"
         args="load depth_image_proc/disparity $(arg manager) $(arg bond)"
-	respawn="$(arg respawn)">
+        respawn="$(arg respawn)">
     <!-- Use raw image for efficiency -->
     <remap from="left/image_rect" to="$(arg depth)/image_rect_raw" />
     <remap from="right" to="$(arg projector)" />

--- a/launch/includes/ir.launch
+++ b/launch/includes/ir.launch
@@ -5,12 +5,14 @@
   <arg name="respawn" default="false" />
   <arg     if="$(arg respawn)" name="bond" value="" />
   <arg unless="$(arg respawn)" name="bond" value="--no-bond" />
-
+  <arg name="ir" />
+  
   <!-- Rectified image -->
   <node pkg="nodelet" type="nodelet" name="rectify_ir"
         args="load image_proc/rectify $(arg manager) $(arg bond)"
-	respawn="$(arg respawn)">
-    <remap from="image_mono"  to="image_raw" />
+        respawn="$(arg respawn)">
+    <remap from="image_mono" to="$(arg ir)/image_raw" />
+    <remap from="image_rect" to="$(arg ir)/image_rect_ir" />
   </node>
 
 </launch>

--- a/launch/includes/manager.launch
+++ b/launch/includes/manager.launch
@@ -8,12 +8,17 @@
   <arg name="debug" default="false" />
   <arg if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <!-- Worker threads -->
+  <arg name="num_worker_threads" />
+  
   <!-- Also globally disable bond heartbeat timeout in debug mode, so everything
        doesn't die when you hit a break point -->
   <param if="$(arg debug)" name="/bond_disable_heartbeat_timeout" value="true" />
 
   <!-- Nodelet manager -->
   <node pkg="nodelet" type="nodelet" name="$(arg name)" args="manager"
-        output="screen" launch-prefix="$(arg launch_prefix)" />
+        output="screen" launch-prefix="$(arg launch_prefix)">
+     <param name="num_worker_threads" value="$(arg num_worker_threads)" />
+  </node>
 
 </launch>

--- a/launch/includes/processing.launch
+++ b/launch/includes/processing.launch
@@ -1,13 +1,21 @@
 <!-- Load full set of processing nodelets for an OpenNI device -->
 <launch>
 
-  <!-- Name of nodelet manager, must be fully resolved -->
+  <!-- Name of nodelet manager -->
   <arg name="manager" />
 
   <!-- Launch robustly (bonds + respawn) or not? -->
   <arg name="respawn" default="false" />
   <arg     if="$(arg respawn)" name="bond" value="" />
   <arg unless="$(arg respawn)" name="bond" value="--no-bond" />
+  
+  <!-- Processing modules -->
+  <arg name="rgb_processing" />
+  <arg name="ir_processing" />
+  <arg name="depth_processing" />
+  <arg name="depth_registered_processing" />
+  <arg name="disparity_processing" />
+  <arg name="disparity_registered_processing" />
   
   <!-- Remapping arguments -->
   <arg name="rgb"              default="rgb" />
@@ -17,28 +25,32 @@
   <arg name="projector"        default="projector" />
 
   <!-- RGB processing -->
-  <include file="$(find openni_launch)/launch/includes/rgb.launch">
+  <include if="$(arg rgb_processing)"
+           file="$(find openni_launch)/launch/includes/rgb.launch">
     <arg name="manager" value="$(arg manager)" />
     <arg name="respawn" value="$(arg respawn)" />
     <arg name="rgb"     value="$(arg rgb)" />
   </include>
 
   <!-- IR processing -->
-  <include file="$(find openni_launch)/launch/includes/ir.launch">
+  <include if="$(arg ir_processing)"
+           file="$(find openni_launch)/launch/includes/ir.launch">
     <arg name="manager" value="$(arg manager)" />
     <arg name="respawn" value="$(arg respawn)" />
     <arg name="ir"      value="$(arg ir)" />
   </include>
 
   <!-- Unregistered depth processing -->
-  <include file="$(find openni_launch)/launch/includes/depth.launch">
+  <include if="$(arg depth_processing)"
+           file="$(find openni_launch)/launch/includes/depth.launch">
     <arg name="manager" value="$(arg manager)" />
     <arg name="respawn" value="$(arg respawn)" />
     <arg name="depth"   value="$(arg depth)" />
   </include>
 
   <!-- Depth-to-RGB registration and processing -->
-  <include file="$(find openni_launch)/launch/includes/depth_registered.launch">
+  <include if="$(arg depth_registered_processing)"
+           file="$(find openni_launch)/launch/includes/depth_registered.launch">
     <arg name="manager"           value="$(arg manager)" />
     <arg name="rgb"               value="$(arg rgb)" />
     <arg name="depth"             value="$(arg depth)" />
@@ -47,7 +59,8 @@
   </include>
 
   <!-- Unregistered disparity image -->
-  <include file="$(find openni_launch)/launch/includes/disparity.launch">
+  <include if="$(arg disparity_processing)"
+           file="$(find openni_launch)/launch/includes/disparity.launch">
     <arg name="manager"   value="$(arg manager)" />
     <arg name="depth"     value="$(arg depth)" />
     <arg name="projector" value="$(arg projector)" />
@@ -55,7 +68,8 @@
   </include>
 
   <!-- Registered disparity image -->
-  <include file="$(find openni_launch)/launch/includes/disparity.launch">
+  <include if="$(arg disparity_registered_processing)"
+           file="$(find openni_launch)/launch/includes/disparity.launch">
     <arg name="manager"   value="$(arg manager)" />
     <arg name="depth"     value="$(arg depth_registered)" />
     <arg name="projector" value="$(arg projector)" />

--- a/launch/includes/processing.launch
+++ b/launch/includes/processing.launch
@@ -17,49 +17,49 @@
   <arg name="projector"        default="projector" />
 
   <!-- RGB processing -->
-  <include file="$(find image_proc)/launch/image_proc.launch"
-	   ns="$(arg rgb)">
+  <include file="$(find openni_launch)/launch/includes/rgb.launch">
     <arg name="manager" value="$(arg manager)" />
     <arg name="respawn" value="$(arg respawn)" />
+    <arg name="rgb"     value="$(arg rgb)" />
   </include>
 
   <!-- IR processing -->
-  <include file="$(find openni_launch)/launch/includes/ir.launch"
-	   ns="$(arg ir)">
+  <include file="$(find openni_launch)/launch/includes/ir.launch">
     <arg name="manager" value="$(arg manager)" />
     <arg name="respawn" value="$(arg respawn)" />
+    <arg name="ir"      value="$(arg ir)" />
   </include>
 
   <!-- Unregistered depth processing -->
-  <include file="$(find openni_launch)/launch/includes/depth.launch"
-	   ns="$(arg depth)">
+  <include file="$(find openni_launch)/launch/includes/depth.launch">
     <arg name="manager" value="$(arg manager)" />
     <arg name="respawn" value="$(arg respawn)" />
+    <arg name="depth"   value="$(arg depth)" />
   </include>
 
   <!-- Depth-to-RGB registration and processing -->
   <include file="$(find openni_launch)/launch/includes/depth_registered.launch">
-    <arg name="manager" value="$(arg manager)" />
-    <arg name="rgb" value="$(arg rgb)" />
-    <arg name="depth" value="$(arg depth)" />
-    <arg name="depth_registered" value="$(arg depth_registered)" />
-    <arg name="respawn" value="$(arg respawn)" />
+    <arg name="manager"           value="$(arg manager)" />
+    <arg name="rgb"               value="$(arg rgb)" />
+    <arg name="depth"             value="$(arg depth)" />
+    <arg name="depth_registered"  value="$(arg depth_registered)" />
+    <arg name="respawn"           value="$(arg respawn)" />
   </include>
 
   <!-- Unregistered disparity image -->
   <include file="$(find openni_launch)/launch/includes/disparity.launch">
-    <arg name="manager" value="$(arg manager)" />
-    <arg name="depth" value="$(arg depth)" />
+    <arg name="manager"   value="$(arg manager)" />
+    <arg name="depth"     value="$(arg depth)" />
     <arg name="projector" value="$(arg projector)" />
-    <arg name="respawn" value="$(arg respawn)" />    
+    <arg name="respawn"   value="$(arg respawn)" />
   </include>
 
   <!-- Registered disparity image -->
   <include file="$(find openni_launch)/launch/includes/disparity.launch">
-    <arg name="manager" value="$(arg manager)" />
-    <arg name="depth" value="$(arg depth_registered)" />
+    <arg name="manager"   value="$(arg manager)" />
+    <arg name="depth"     value="$(arg depth_registered)" />
     <arg name="projector" value="$(arg projector)" />
-    <arg name="respawn" value="$(arg respawn)" />    
+    <arg name="respawn"   value="$(arg respawn)" />
   </include>
 
 </launch>

--- a/launch/includes/rgb.launch
+++ b/launch/includes/rgb.launch
@@ -1,0 +1,37 @@
+<!-- Load processing nodelets for the RGB camera -->
+<launch>
+
+  <arg name="manager" />
+  <arg name="respawn" default="false" />
+  <arg name="rgb" />
+  <!-- TODO Arguments for debayer, interpolation methods? -->
+
+  <arg     if="$(arg respawn)" name="bond" value="" />
+  <arg unless="$(arg respawn)" name="bond" value="--no-bond" />
+
+  <!-- Debayered images -->
+  <node pkg="nodelet" type="nodelet" name="debayer"
+        args="load image_proc/debayer $(arg manager) $(arg bond)"
+        respawn="$(arg respawn)">
+    <remap from="image_raw"   to="$(arg rgb)/image_raw" />
+    <remap from="image_mono"  to="$(arg rgb)/image_mono" />
+    <remap from="image_color" to="$(arg rgb)/image_color" />
+  </node>
+
+  <!-- Monochrome rectified image -->
+  <node pkg="nodelet" type="nodelet" name="rectify_mono"
+        args="load image_proc/rectify $(arg manager) $(arg bond)"
+        respawn="$(arg respawn)">
+    <remap from="image_mono" to="$(arg rgb)/image_mono" />
+    <remap from="image_rect" to="$(arg rgb)/image_rect_mono" />
+  </node>
+
+  <!-- Color rectified image -->
+  <node pkg="nodelet" type="nodelet" name="rectify_color"
+        args="load image_proc/rectify $(arg manager) $(arg bond)"
+        respawn="$(arg respawn)">
+    <remap from="image_mono" to="$(arg rgb)/image_color" />
+    <remap from="image_rect" to="$(arg rgb)/image_rect_color" />
+  </node>
+
+</launch>

--- a/launch/openni.launch
+++ b/launch/openni.launch
@@ -36,6 +36,13 @@
        supplying a more accurate tf tree from calibration. -->
   <arg name="load_driver" default="true" />
   <arg name="publish_tf" default="true" />
+  <!-- Processing Modules -->
+  <arg name="rgb_processing"                  default="true"/>
+  <arg name="ir_processing"                   default="true"/>
+  <arg name="depth_processing"                default="true"/>
+  <arg name="depth_registered_processing"     default="true"/>
+  <arg name="disparity_processing"            default="true"/>
+  <arg name="disparity_registered_processing" default="true"/>
 
   <!-- Disable bond topics by default -->
   <arg name="bond" default="false" /> <!-- DEPRECATED, use respawn arg instead -->
@@ -77,13 +84,19 @@
     
     <!-- Load standard constellation of processing nodelets -->
     <include file="$(find openni_launch)/launch/includes/processing.launch">
-      <arg name="manager"               value="$(arg manager)" />
-      <arg name="rgb"                   value="$(arg rgb)" />
-      <arg name="ir"                    value="$(arg ir)" />
-      <arg name="depth"                 value="$(arg depth)" />
-      <arg name="depth_registered"      value="$(arg depth_registered)" />
-      <arg name="projector"             value="$(arg projector)" />
-      <arg name="respawn"               value="$(arg respawn)" />
+      <arg name="manager"                         value="$(arg manager)" />
+      <arg name="rgb"                             value="$(arg rgb)" />
+      <arg name="ir"                              value="$(arg ir)" />
+      <arg name="depth"                           value="$(arg depth)" />
+      <arg name="depth_registered"                value="$(arg depth_registered)" />
+      <arg name="projector"                       value="$(arg projector)" />
+      <arg name="respawn"                         value="$(arg respawn)" />
+      <arg name="rgb_processing"                  value="$(arg rgb_processing)" />
+      <arg name="ir_processing"                   value="$(arg ir_processing)" />
+      <arg name="depth_processing"                value="$(arg depth_processing)" />
+      <arg name="depth_registered_processing"     value="$(arg depth_registered_processing)" />
+      <arg name="disparity_processing"            value="$(arg disparity_processing)" />
+      <arg name="disparity_registered_processing" value="$(arg disparity_registered_processing)" />
     </include>
   
   </group> <!-- camera -->

--- a/launch/openni.launch
+++ b/launch/openni.launch
@@ -41,22 +41,22 @@
   <arg name="bond" default="false" /> <!-- DEPRECATED, use respawn arg instead -->
   <arg name="respawn" default="$(arg bond)" />
 
-  <!-- Start nodelet manager in top-level namespace -->
-  <arg name="manager" value="$(arg camera)_nodelet_manager" />
-  <arg name="debug" default="false" /> <!-- Run manager in GDB? -->
-  <include file="$(find openni_launch)/launch/includes/manager.launch">
-    <arg name="name" value="$(arg manager)" />
-    <arg name="debug" value="$(arg debug)" />
-  </include>
-
   <!-- Push down all topics/nodelets into "camera" namespace -->
   <group ns="$(arg camera)">
+  
+    <!-- Start nodelet manager in top-level namespace -->
+    <arg name="manager" value="$(arg camera)_nodelet_manager" />
+    <arg name="debug" default="false" /> <!-- Run manager in GDB? -->
+    <include file="$(find openni_launch)/launch/includes/manager.launch">
+      <arg name="name" value="$(arg manager)" />
+      <arg name="debug" value="$(arg debug)" />
+    </include>
 
     <!-- Load driver -->
     <include if="$(arg load_driver)"
 	     file="$(find openni_launch)/launch/includes/device.launch">
       <!-- Could really use some syntactic sugar for this -->
-      <arg name="manager"               value="/$(arg manager)" /> <!-- Fully resolved -->
+      <arg name="manager"               value="$(arg manager)" />
       <arg name="device_id"             value="$(arg device_id)" />
       <arg name="rgb_frame_id"          value="$(arg rgb_frame_id)" />
       <arg name="depth_frame_id"        value="$(arg depth_frame_id)" />
@@ -70,10 +70,10 @@
       <arg name="projector"             value="$(arg projector)" />
       <arg name="respawn"               value="$(arg respawn)" />
     </include>
-
+    
     <!-- Load standard constellation of processing nodelets -->
     <include file="$(find openni_launch)/launch/includes/processing.launch">
-      <arg name="manager"               value="/$(arg manager)" /> <!-- Fully resolved -->
+      <arg name="manager"               value="$(arg manager)" />
       <arg name="rgb"                   value="$(arg rgb)" />
       <arg name="ir"                    value="$(arg ir)" />
       <arg name="depth"                 value="$(arg depth)" />
@@ -81,7 +81,7 @@
       <arg name="projector"             value="$(arg projector)" />
       <arg name="respawn"               value="$(arg respawn)" />
     </include>
-
+  
   </group> <!-- camera -->
 
   <!-- Load reasonable defaults for the relative pose between cameras -->

--- a/launch/openni.launch
+++ b/launch/openni.launch
@@ -11,7 +11,7 @@
          "B00367707227042B": Use device with given serial number
          "#1"              : Use first device found
          "2@3"             : Use device on USB bus 2, address 3
-	 "2@0"             : Use first device found on USB bus 2
+         "2@0"             : Use first device found on USB bus 2
     -->
   <arg name="device_id" default="#1" />
 
@@ -41,6 +41,9 @@
   <arg name="bond" default="false" /> <!-- DEPRECATED, use respawn arg instead -->
   <arg name="respawn" default="$(arg bond)" />
 
+  <!-- Worker threads for the nodelet manager -->
+  <arg name="num_worker_threads" default="4" />
+
   <!-- Push down all topics/nodelets into "camera" namespace -->
   <group ns="$(arg camera)">
   
@@ -48,8 +51,9 @@
     <arg name="manager" value="$(arg camera)_nodelet_manager" />
     <arg name="debug" default="false" /> <!-- Run manager in GDB? -->
     <include file="$(find openni_launch)/launch/includes/manager.launch">
-      <arg name="name" value="$(arg manager)" />
-      <arg name="debug" value="$(arg debug)" />
+      <arg name="name"                value="$(arg manager)" />
+      <arg name="debug"               value="$(arg debug)" />
+      <arg name="num_worker_threads"  value="$(arg num_worker_threads)" />
     </include>
 
     <!-- Load driver -->


### PR DESCRIPTION
This is a slightly different patch for issue #2.
The core changes are:
- Nodelet manager runs on the same level as the nodelets, thereby removing the need for an absolute manager name as nodelet parameter. This allows pushing down all openni node's and nodelets in extra namespaces, e.g. for different robots, applications etc.
- Sorts the various nodelet topics (depth, ir, rgb, ...) by remapping the nodelets' i/o topics

Additional changes:
- The worker threads parameter has been made accessible.
- Assumed duplicated include of depth nodelets for depth_registered has been removed. This also makes the service registration error go away.
