### PR TITLE
test the ROS launch files, fix some errors (#10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,10 @@ install(DIRECTORY launch
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/
 )
 
+# unit tests are enabled selectively
+if (CATKIN_ENABLE_TESTING)
+  # check that all launch file dependencies are declared correctly
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch)
+  roslaunch_add_file_check(launch/includes)
+endif (CATKIN_ENABLE_TESTING)

--- a/launch/includes/depth_registered.launch
+++ b/launch/includes/depth_registered.launch
@@ -1,18 +1,16 @@
 <launch>
 
   <!-- have all the old parameters to prevent roslaunch errors -->
-  <arg name="manager" default="" />
-  <arg name="rgb" default="" />
-  <arg name="depth" default="" />
-  <arg name="publish_metric_rect" default="" />
-  <arg name="allow_software_registration" default="" />
   <arg name="allow_hardware_registration" default="" />
-  <arg name="points_xyzrgb" default="" />
-  <arg name="respawn" default="" />
-  <arg name="rgb" default="" />
+  <arg name="allow_software_registration" default="" />
   <arg name="depth" default="" />
   <arg name="depth_registered" default="" />
   <arg name="depth_registration" default="" />
+  <arg name="manager" default="" />
+  <arg name="points_xyzrgb" default="" />
+  <arg name="publish_metric_rect" default="" />
+  <arg name="respawn" default="" />
+  <arg name="rgb" default="" />
   <arg name="suffix" default="" />
 
   <!-- deprecation notice -->

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   
   <build_depend>openni_camera</build_depend>
   <build_depend>rgbd_launch</build_depend>
+  <build_depend>roslaunch</build_depend> <!-- unit test only -->
 
   <run_depend>openni_camera</run_depend>
   <run_depend>rgbd_launch</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <build_depend>rgbd_launch</build_depend>
   <build_depend>roslaunch</build_depend> <!-- unit test only -->
 
+  <run_depend>nodelet</run_depend>
   <run_depend>openni_camera</run_depend>
   <run_depend>rgbd_launch</run_depend>
 


### PR DESCRIPTION
Adds unit test checking for launch file syntax and dependencies.

Fixes problems found by those checks:
- added missing **nodelet** dependency
- removed duplicate arg declarations for **depth** and **rgb**
- alphabetized arg declarations to prevent future duplications in that file
