### PR TITLE
Fix selection of a Xtion device by serial number

### DIFF
--- a/launch/includes/device.launch
+++ b/launch/includes/device.launch
@@ -27,7 +27,7 @@
   <node pkg="nodelet" type="nodelet" name="driver" 
         args="load openni_camera/driver $(arg manager) $(arg bond)"
 	respawn="$(arg respawn)">
-    <param name="device_id" value="$(arg device_id)" />
+    <param name="device_id" value="$(arg device_id)" type="string" />
     <param name="rgb_camera_info_url"   value="$(arg rgb_camera_info_url)" />
     <param name="depth_camera_info_url" value="$(arg depth_camera_info_url)" />
     <param name="rgb_frame_id"   value="$(arg rgb_frame_id)" />


### PR DESCRIPTION
The openni driver expects the device_id parameter to be a string, but the serial numbers of a Xtion device includes only numbers.
In this case, if no type attribute is provided, the openni driver receives an empty device_id.
Adding the type="string" attribute fixes this problem.
