### PR TITLE
adding depth_registered_filtered injection

### DIFF
--- a/launch/openni.launch
+++ b/launch/openni.launch
@@ -26,11 +26,12 @@
   <arg name="depth_registration" default="false" />
 
   <!-- Arguments for remapping all device namespaces -->
-  <arg name="rgb"              default="rgb" />
-  <arg name="ir"               default="ir" />
-  <arg name="depth"            default="depth" />
-  <arg name="depth_registered" default="depth_registered" />
-  <arg name="projector"        default="projector" />
+  <arg name="rgb"                       default="rgb" />
+  <arg name="ir"                        default="ir" />
+  <arg name="depth"                     default="depth" />
+  <arg name="depth_registered"          default="depth_registered" />
+  <arg name="depth_registered_filtered" default="depth_registered" />
+  <arg name="projector"                 default="projector" />
 
   <!-- Optionally suppress loading the driver nodelet and/or publishing the default tf
        tree. Useful if you are playing back recorded raw data from a bag, or are
@@ -92,6 +93,7 @@
       <arg name="ir"                              value="$(arg ir)" />
       <arg name="depth"                           value="$(arg depth)" />
       <arg name="depth_registered"                value="$(arg depth_registered)" />
+      <arg name="depth_registered_filtered"       value="$(arg depth_registered_filtered)" />
       <arg name="projector"                       value="$(arg projector)" />
       <arg name="respawn"                         value="$(arg respawn)" />
       <arg name="rgb_processing"                  value="$(arg rgb_processing)" />


### PR DESCRIPTION
This enables the "injection" of a depth image filter into the middle of the rgbd processing pipeline. This is useful for efficiently removing known structure from the point cloud like a robotic manipulator.

It's done by defining the "depth_registered_filtered" argument, which then gets used by the point cloud processing node instead of the raw "depth_registered" topic.
