### PR TITLE
adjust frame ids to TF2

### DIFF
--- a/launch/openni_tf_prefix.launch
+++ b/launch/openni_tf_prefix.launch
@@ -1,11 +1,12 @@
-<!-- Entry point for using OpenNI devices -->
+<!-- Entry point for using OpenNI devices (if you still use tf_prefix) -->
 <launch>
 
   <!-- "camera" should uniquely identify the device. All topics are pushed down
        into the "camera" namespace, and it is prepended to tf frame ids. -->
   <arg name="camera" default="camera" />
-  <arg name="rgb_frame_id"   default="$(arg camera)_rgb_optical_frame" />
-  <arg name="depth_frame_id" default="$(arg camera)_depth_optical_frame" />
+  <arg name="tf_prefix" default="" />
+  <arg name="rgb_frame_id"   default="$(arg tf_prefix)/$(arg camera)_rgb_optical_frame" />
+  <arg name="depth_frame_id" default="$(arg tf_prefix)/$(arg camera)_depth_optical_frame" />
 
   <!-- device_id can have the following formats:
          "B00367707227042B": Use device with given serial number
@@ -109,6 +110,7 @@
   <include if="$(arg publish_tf)"
 	   file="$(find rgbd_launch)/launch/kinect_frames.launch">
     <arg name="camera" value="$(arg camera)" />
+    <arg name="tf_prefix" value="$(arg tf_prefix)" />
   </include>
 
 </launch>


### PR DESCRIPTION
Removes the leading '/' from the TF frames in case tf_prefix is empty,
which fixes this error:

```
[ WARN] [1432284298.914340788]: TF2 exception:
Invalid argument "/camera_rgb_optical_frame" passed to lookupTransform argument target_frame in tf2 frame_ids cannot start with a '/' like:  (/camera/camera_nodelet_manager)
```

Actually, tf_prefix is now ignored altogether.
